### PR TITLE
- Token Auth changes

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -241,7 +241,7 @@ type locationWithOffSecs struct {
 type connPool struct {
 	dpiPool         *C.dpiPool
 	key             string
-	tokenCallBackid uint64
+	tokenCallBackID uint64
 	params          commonAndPoolParams
 }
 
@@ -250,7 +250,7 @@ func (p *connPool) Purge() {
 	dpiPool := p.dpiPool
 	p.dpiPool = nil
 	if dpiPool != nil {
-		UnRegisterTokenCallback(p.tokenCallBackid)
+		UnRegisterTokenCallback(p.tokenCallBackID)
 		C.dpiPool_close(dpiPool, C.DPI_MODE_POOL_CLOSE_FORCE)
 	}
 }
@@ -911,7 +911,7 @@ func (d *drv) createPool(P commonAndPoolParams) (*connPool, error) {
 	}
 	C.dpiPool_setStmtCacheSize(dp, stmtCacheSize)
 
-	return &connPool{dpiPool: dp, params: P, tokenCallBackid: id}, nil
+	return &connPool{dpiPool: dp, params: P, tokenCallBackID: id}, nil
 }
 
 // PoolStats contains Oracle session pool statistics

--- a/drv.go
+++ b/drv.go
@@ -846,7 +846,7 @@ func (d *drv) createPool(P commonAndPoolParams) (*connPool, error) {
 	// if specifically reqeuested or if external authentication is desirable
 	if poolCreateParams.externalAuth == 1 || P.Heterogeneous {
 		if P.Token == "" {
-			// Token Authentication needs homogeneneous to be set
+			// Reset homogeneous only for non-token Authentication
 			poolCreateParams.homogeneous = 0
 		}
 	}

--- a/drv.go
+++ b/drv.go
@@ -336,7 +336,9 @@ var cUTF8, cDriverName = C.CString("UTF-8"), C.CString(DriverName)
 // initCommonCreateParams initializes ODPI-C common creation parameters used for creating pools and
 // standalone connections. The C strings for the encoding and driver name are
 // defined at the package level for convenience.
-func (d *drv) initCommonCreateParams(P *C.dpiCommonCreateParams, enableEvents bool, stmtCacheSize int, charset string) error {
+func (d *drv) initCommonCreateParams(P *C.dpiCommonCreateParams, enableEvents bool,
+	stmtCacheSize int, charset string, token string, privateKey string,
+	cAccessToken *C.dpiAccessToken) error {
 	// initialize ODPI-C structure for common creation parameters
 	if err := d.checkExec(func() C.int {
 		return C.dpiContext_initCommonCreateParams(d.dpiContext, P)
@@ -368,6 +370,17 @@ func (d *drv) initCommonCreateParams(P *C.dpiCommonCreateParams, enableEvents bo
 		} else {
 			P.stmtCacheSize = C.uint32_t(stmtCacheSize)
 		}
+	}
+
+	// Token Based Authentication.
+	if token != "" {
+		cAccessToken.token = C.CString(token)
+		cAccessToken.tokenLength = C.uint32_t(len(token))
+		if privateKey != "" {
+			cAccessToken.privateKey = C.CString(privateKey)
+			cAccessToken.privateKeyLength = C.uint32_t(len(privateKey))
+		}
+		P.accessToken = cAccessToken
 	}
 
 	return nil
@@ -476,9 +489,27 @@ func (d *drv) acquireConn(pool *connPool, P commonAndConnParams) (*C.dpiConn, bo
 	// used when a standalone connection is being created; when a connection is
 	// being acquired from the pool this structure is not needed
 	var commonCreateParamsPtr *C.dpiCommonCreateParams
+	var cAccessToken *C.dpiAccessToken
+
 	if pool == nil {
 		var commonCreateParams C.dpiCommonCreateParams
-		if err := d.initCommonCreateParams(&commonCreateParams, P.EnableEvents, P.StmtCacheSize, P.Charset); err != nil {
+		if P.Token != "" { // Token Authentication requested.
+			mem := C.malloc(C.sizeof_dpiAccessToken)
+			cAccessToken = (*C.dpiAccessToken)(mem)
+			defer func() {
+				if cAccessToken != nil {
+					if cAccessToken.token != nil {
+						C.free(unsafe.Pointer(cAccessToken.token))
+					}
+					if cAccessToken.privateKey != nil {
+						C.free(unsafe.Pointer(cAccessToken.privateKey))
+					}
+					C.free(unsafe.Pointer(cAccessToken))
+				}
+			}()
+		}
+		if err := d.initCommonCreateParams(&commonCreateParams, P.EnableEvents, P.StmtCacheSize,
+			P.Charset, P.Token, P.PrivateKey, cAccessToken); err != nil {
 			return nil, false, nil, err
 		}
 		commonCreateParamsPtr = &commonCreateParams
@@ -746,7 +777,24 @@ func (d *drv) createPool(P commonAndPoolParams) (*connPool, error) {
 
 	// set up common creation parameters
 	var commonCreateParams C.dpiCommonCreateParams
-	if err := d.initCommonCreateParams(&commonCreateParams, P.EnableEvents, P.StmtCacheSize, P.Charset); err != nil {
+	var cAccessToken *C.dpiAccessToken
+	if P.Token != "" { // Token Based Authentication requested.
+		mem := C.malloc(C.sizeof_dpiAccessToken)
+		cAccessToken = (*C.dpiAccessToken)(mem)
+		defer func() {
+			if cAccessToken != nil {
+				if cAccessToken.token != nil {
+					C.free(unsafe.Pointer(cAccessToken.token))
+				}
+				if cAccessToken.privateKey != nil {
+					C.free(unsafe.Pointer(cAccessToken.privateKey))
+				}
+				C.free(unsafe.Pointer(cAccessToken))
+			}
+		}()
+	}
+	if err := d.initCommonCreateParams(&commonCreateParams, P.EnableEvents, P.StmtCacheSize,
+		P.Charset, P.Token, P.PrivateKey, cAccessToken); err != nil {
 		return nil, err
 	}
 
@@ -805,7 +853,16 @@ func (d *drv) createPool(P commonAndPoolParams) (*connPool, error) {
 	// assign homogeneous pool flag; default is true so need to clear the flag
 	// if specifically reqeuested or if external authentication is desirable
 	if poolCreateParams.externalAuth == 1 || P.Heterogeneous {
-		poolCreateParams.homogeneous = 0
+		if P.Token == "" {
+			// Token Authentication needs homogeneneous to be set
+			poolCreateParams.homogeneous = 0
+		}
+	}
+
+	if P.TokenCB != nil {
+		//typedef int (*dpiAccessTokenCallback)(void *context,
+		//    dpiAccessToken *accessToken);
+		RegisterTokenCallback(&poolCreateParams, P.TokenCB, P.TokenCBCtx)
 	}
 
 	// setup credentials

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -53,6 +53,7 @@ type CommonSimpleParams struct {
 	Timezone                *time.Location
 	ConfigDir, LibDir       string
 	Username, ConnectString string
+	Token, PrivateKey       string
 	Password                Password
 	Charset                 string
 	// StmtCacheSize of 0 means the default, -1 to disable the stmt cache completely
@@ -133,6 +134,12 @@ func (P CommonSimpleParams) String() string {
 	if P.InitOnNewConn {
 		q.Add("initOnNewConnection", "1")
 	}
+	if P.Token != "" {
+		q.Add("token", P.Token)
+	}
+	if P.PrivateKey != "" {
+		q.Add("privateKey", P.PrivateKey)
+	}
 	if P.NoBreakOnContextCancel {
 		q.Add("noBreakOnContextCancel", "1")
 	}
@@ -182,6 +189,12 @@ func (P ConnParams) String() string {
 	return q.String()
 }
 
+// AccessToken Data for Token Authentication.
+type AccessToken struct {
+	Token      string
+	PrivateKey string
+}
+
 // PoolParams holds the configuration of the Oracle Session Pool.
 //
 // For details, see https://oracle.github.io/odpi/doc/structs/dpiPoolCreateParams.html#dpipoolcreateparams
@@ -193,6 +206,8 @@ type PoolParams struct {
 	WaitTimeout, MaxLifeTime, SessionTimeout   time.Duration
 	PingInterval                               time.Duration
 	Heterogeneous, ExternalAuth                bool
+	TokenCB                                    func(context.Context, *AccessToken) error
+	TokenCBCtx								   context.Context
 }
 
 // String returns the string representation of PoolParams.
@@ -337,6 +352,12 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	q.Add("poolSessionMaxLifetime", P.MaxLifeTime.String())
 	q.Add("poolSessionTimeout", P.SessionTimeout.String())
 	q.Add("pingInterval", P.PingInterval.String())
+	if P.Token != "" {
+		q.Add("token", P.Token)
+	}
+	if P.PrivateKey != "" {
+		q.Add("privateKey", P.PrivateKey)
+	}
 	as := acquireParamsArray(1)
 	defer releaseParamsArray(as)
 	for _, kv := range P.AlterSession {
@@ -450,6 +471,10 @@ func Parse(dataSourceName string) (ConnectionParams, error) {
 					P.Password.Set(value)
 				case "charset":
 					P.Charset = value
+				case "token":
+					P.Token = value
+				case "privateKey":
+					P.PrivateKey = value
 				case "alterSession", "onInit", "shardingKey", "superShardingKey":
 					q.Add(key, value)
 				default:

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -134,12 +134,6 @@ func (P CommonSimpleParams) String() string {
 	if P.InitOnNewConn {
 		q.Add("initOnNewConnection", "1")
 	}
-	if P.Token != "" {
-		q.Add("token", P.Token)
-	}
-	if P.PrivateKey != "" {
-		q.Add("privateKey", P.PrivateKey)
-	}
 	if P.NoBreakOnContextCancel {
 		q.Add("noBreakOnContextCancel", "1")
 	}
@@ -352,12 +346,6 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	q.Add("poolSessionMaxLifetime", P.MaxLifeTime.String())
 	q.Add("poolSessionTimeout", P.SessionTimeout.String())
 	q.Add("pingInterval", P.PingInterval.String())
-	if P.Token != "" {
-		q.Add("token", P.Token)
-	}
-	if P.PrivateKey != "" {
-		q.Add("privateKey", P.PrivateKey)
-	}
 	as := acquireParamsArray(1)
 	defer releaseParamsArray(as)
 	for _, kv := range P.AlterSession {

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -201,7 +201,7 @@ type PoolParams struct {
 	PingInterval                               time.Duration
 	Heterogeneous, ExternalAuth                bool
 	TokenCB                                    func(context.Context, *AccessToken) error
-	TokenCBCtx								   context.Context
+	TokenCBCtx                                 context.Context
 }
 
 // String returns the string representation of PoolParams.
@@ -299,6 +299,13 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 	if withPassword {
 		q.Add("password", P.Password.Secret())
 		q.Add("newPassword", P.NewPassword.Secret())
+		if P.Token != "" {
+			q.Add("token", P.Token)
+		}
+		if P.PrivateKey != "" {
+			q.Add("privateKey", P.PrivateKey)
+		}
+
 	} else {
 		q.Add("password", P.Password.String())
 		if !P.NewPassword.IsZero() {

--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -305,7 +305,6 @@ func (P ConnectionParams) string(class, withPassword bool) string {
 		if P.PrivateKey != "" {
 			q.Add("privateKey", P.PrivateKey)
 		}
-
 	} else {
 		q.Add("password", P.Password.String())
 		if !P.NewPassword.IsZero() {

--- a/token.c
+++ b/token.c
@@ -4,6 +4,5 @@
 void TokenCallbackHandler(void *context, dpiAccessToken *access_token);
 
 void TokenCallbackHandlerDebug(void *context, dpiAccessToken *acToken) {
-	fprintf(stderr, "callback called\n");
 	TokenCallbackHandler(context, acToken);
 }

--- a/token.c
+++ b/token.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "dpiImpl.h"
+
+void TokenCallbackHandler(void *context, dpiAccessToken *access_token);
+
+void TokenCallbackHandlerDebug(void *context, dpiAccessToken *acToken) {
+	fprintf(stderr, "callback called\n");
+	TokenCallbackHandler(context, acToken);
+}

--- a/token.go
+++ b/token.go
@@ -62,8 +62,6 @@ func TokenCallbackHandler(ctx unsafe.Pointer, accessTokenC *C.dpiAccessToken) {
 }
 
 // RegisterTokenCallback.
-//
-// This code is EXPERIMENTAL yet!
 func RegisterTokenCallback(poolCreateParams *C.dpiPoolCreateParams,
 	tokenGenFn func(context.Context, *dsn.AccessToken) error,
 	tokenCtx context.Context) {

--- a/token.go
+++ b/token.go
@@ -98,7 +98,9 @@ func RegisterTokenCallback(poolCreateParams *C.dpiPoolCreateParams,
 // UnRegisterTokenCallback will remove the token callback data registered
 // during pool creation.
 func UnRegisterTokenCallback(key uint64) {
+	accessTokenCBsMu.Lock()
 	value, ok := accessTokenCBs[key]
+	accessTokenCBsMu.Unlock()
 	if ok {
 		if value.ctoken != nil {
 			C.free(unsafe.Pointer(value.ctoken))

--- a/token.go
+++ b/token.go
@@ -1,4 +1,4 @@
-// Copyright 2017, 2020 The Godror Authors
+// Copyright 2024 The Godror Authors
 //
 //
 // SPDX-License-Identifier: UPL-1.0 OR Apache-2.0

--- a/token.go
+++ b/token.go
@@ -79,7 +79,6 @@ func TokenCallbackHandler(ctx unsafe.Pointer, accessTokenC *C.dpiAccessToken) {
 func RegisterTokenCallback(poolCreateParams *C.dpiPoolCreateParams,
 	tokenGenFn func(context.Context, *dsn.AccessToken) error,
 	tokenCtx context.Context, id *uint64) {
-
 	// typedef int (*dpiAccessTokenCallback)(void* context, dpiAccessToken *accessToken);
 	poolCreateParams.accessTokenCallback = C.dpiAccessTokenCallback(C.TokenCallbackHandlerDebug)
 

--- a/token.go
+++ b/token.go
@@ -17,6 +17,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"github.com/godror/godror/dsn"
 	"log"
 	"sync"
@@ -24,17 +25,20 @@ import (
 )
 
 // AccessToken Callback information.
-type AccessTokenCB struct {
-	ctx      context.Context
-	callback func(context.Context, *dsn.AccessToken) error
-	ID       uint64
+type accessTokenCB struct {
+	ctx         context.Context
+	callback    func(context.Context, *dsn.AccessToken) error
+	id          uint64
+	ctoken      *C.char
+	cprivateKey *C.char
 }
 
-// Cannot pass *AccessTokenCB to C, so pass an uint64 that points to this map entry
+// Cannot pass *accessTokenCB to C, so pass an uint64 that points to
+// this map entry
 var (
-	accessTokenMu sync.Mutex
-	accessTokens  = make(map[uint64]*AccessTokenCB)
-	accessTokenID uint64
+	accessTokenCBsMu sync.Mutex
+	accessTokenCBs   = make(map[uint64]*accessTokenCB)
+	accessTokenCBsID uint64
 )
 
 // tokenCallbackHandler is the callback for C code on token expiry.
@@ -42,41 +46,68 @@ var (
 //export TokenCallbackHandler
 func TokenCallbackHandler(ctx unsafe.Pointer, accessTokenC *C.dpiAccessToken) {
 	log.Printf("CB %p %+v", ctx, accessTokenC)
-	accessTokenMu.Lock()
-	acessTokenCB := accessTokens[*((*uint64)(ctx))]
-	accessTokenMu.Unlock()
+	accessTokenCBsMu.Lock()
+	acessTokenCB := accessTokenCBs[*((*uint64)(ctx))]
+	accessTokenCBsMu.Unlock()
 
 	// Call user function which provides the new token and privateKey.
 	var refreshAccessToken dsn.AccessToken
 	if err := acessTokenCB.callback(acessTokenCB.ctx, &refreshAccessToken); err != nil {
 		log.Printf("Token Generation Failed CB %p %+v", ctx, acessTokenCB)
 	}
-
+	if acessTokenCB.ctoken != nil {
+		C.free(unsafe.Pointer(acessTokenCB.ctoken))
+		fmt.Println("free prev token ")
+	}
+	if acessTokenCB.cprivateKey != nil {
+		fmt.Println("free prev privatekey ")
+		C.free(unsafe.Pointer(acessTokenCB.cprivateKey))
+	}
 	token := refreshAccessToken.Token
 	privateKey := refreshAccessToken.PrivateKey
 	// TBD free these strings.
 	accessTokenC.token = C.CString(token)
+	acessTokenCB.ctoken = accessTokenC.token
 	accessTokenC.tokenLength = C.uint32_t(len(token))
 	accessTokenC.privateKey = C.CString(privateKey)
+	acessTokenCB.cprivateKey = accessTokenC.privateKey
 	accessTokenC.privateKeyLength = C.uint32_t(len(privateKey))
 }
 
-// RegisterTokenCallback.
+// RegisterTokenCallback will add an entry of callback data in a map.
 func RegisterTokenCallback(poolCreateParams *C.dpiPoolCreateParams,
 	tokenGenFn func(context.Context, *dsn.AccessToken) error,
-	tokenCtx context.Context) {
+	tokenCtx context.Context, id *uint64) {
 
 	// typedef int (*dpiAccessTokenCallback)(void* context, dpiAccessToken *accessToken);
 	poolCreateParams.accessTokenCallback = C.dpiAccessTokenCallback(C.TokenCallbackHandlerDebug)
 
-	// cannot pass &token to C, so pass indirectly
-	aToken := AccessTokenCB{callback: tokenGenFn, ctx: tokenCtx}
-	accessTokenMu.Lock()
-	accessTokenID++
-	aToken.ID = accessTokenID
-	accessTokens[aToken.ID] = &aToken
-	accessTokenMu.Unlock()
+	// cannot pass &accessTokenCB to C, so pass indirectly
+	tokenCB := accessTokenCB{callback: tokenGenFn, ctx: tokenCtx}
+	accessTokenCBsMu.Lock()
+	accessTokenCBsID++
+	tokenCB.id = accessTokenCBsID
+	*id = accessTokenCBsID
+	accessTokenCBs[tokenCB.id] = &tokenCB
+	accessTokenCBsMu.Unlock()
 	tokenID := (*C.uint64_t)(C.malloc(8))
-	*tokenID = C.uint64_t(accessTokenID)
+	*tokenID = C.uint64_t(accessTokenCBsID)
 	poolCreateParams.accessTokenCallbackContext = unsafe.Pointer(tokenID)
+}
+
+// UnRegisterTokenCallback will remove the token callback data registered
+// during pool creation.
+func UnRegisterTokenCallback(key uint64) {
+	value, ok := accessTokenCBs[key]
+	if ok {
+		if value.ctoken != nil {
+			C.free(unsafe.Pointer(value.ctoken))
+			fmt.Println("free prev token in unregiser ")
+		}
+		if value.cprivateKey != nil {
+			fmt.Println("free prev privatekey in unregister  ")
+			C.free(unsafe.Pointer(value.cprivateKey))
+		}
+		delete(accessTokenCBs, key)
+	}
 }

--- a/token.go
+++ b/token.go
@@ -1,0 +1,84 @@
+// Copyright 2017, 2020 The Godror Authors
+//
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+package godror
+
+/*
+#include <stdlib.h>
+#include <stdio.h>
+#include "dpiImpl.h"
+
+int TokenCallbackHandlerDebug(void* context, dpiAccessToken *token);
+
+*/
+import "C"
+
+import (
+	"context"
+	"github.com/godror/godror/dsn"
+	"log"
+	"sync"
+	"unsafe"
+)
+
+// AccessToken Callback information.
+type AccessTokenCB struct {
+	ctx      context.Context
+	callback func(context.Context, *dsn.AccessToken) error
+	ID       uint64
+}
+
+// Cannot pass *AccessTokenCB to C, so pass an uint64 that points to this map entry
+var (
+	accessTokenMu sync.Mutex
+	accessTokens  = make(map[uint64]*AccessTokenCB)
+	accessTokenID uint64
+)
+
+// tokenCallbackHandler is the callback for C code on token expiry.
+//
+//export TokenCallbackHandler
+func TokenCallbackHandler(ctx unsafe.Pointer, accessTokenC *C.dpiAccessToken) {
+	log.Printf("CB %p %+v", ctx, accessTokenC)
+	accessTokenMu.Lock()
+	acessTokenCB := accessTokens[*((*uint64)(ctx))]
+	accessTokenMu.Unlock()
+
+	// Call user function which provides the new token and privateKey.
+	var refreshAccessToken dsn.AccessToken
+	if err := acessTokenCB.callback(acessTokenCB.ctx, &refreshAccessToken); err != nil {
+		log.Printf("Token Generation Failed CB %p %+v", ctx, acessTokenCB)
+	}
+
+	token := refreshAccessToken.Token
+	privateKey := refreshAccessToken.PrivateKey
+	// TBD free these strings.
+	accessTokenC.token = C.CString(token)
+	accessTokenC.tokenLength = C.uint32_t(len(token))
+	accessTokenC.privateKey = C.CString(privateKey)
+	accessTokenC.privateKeyLength = C.uint32_t(len(privateKey))
+}
+
+// RegisterTokenCallback.
+//
+// This code is EXPERIMENTAL yet!
+func RegisterTokenCallback(poolCreateParams *C.dpiPoolCreateParams,
+	tokenGenFn func(context.Context, *dsn.AccessToken) error,
+	tokenCtx context.Context) {
+
+	// typedef int (*dpiAccessTokenCallback)(void* context, dpiAccessToken *accessToken);
+	poolCreateParams.accessTokenCallback = C.dpiAccessTokenCallback(C.TokenCallbackHandlerDebug)
+
+	// cannot pass &token to C, so pass indirectly
+	aToken := AccessTokenCB{callback: tokenGenFn, ctx: tokenCtx}
+	accessTokenMu.Lock()
+	accessTokenID++
+	aToken.ID = accessTokenID
+	accessTokens[aToken.ID] = &aToken
+	accessTokenMu.Unlock()
+	tokenID := (*C.uint64_t)(C.malloc(8))
+	*tokenID = C.uint64_t(accessTokenID)
+	poolCreateParams.accessTokenCallbackContext = unsafe.Pointer(tokenID)
+}

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -47,9 +47,7 @@ func TestTokenAuthCallBack(t *testing.T) {
 	P.Username = ""
 	P.Password.Reset()
 	const hostName = "test.clouddb.com"
-	const pno = 443
 	tokenCtx := context.WithValue(context.Background(), "host", hostName)
-	tokenCtx = context.WithValue(tokenCtx, "port", pno)
 	cb := func(ctx context.Context, tok *dsn.AccessToken) error {
 
 		if !strings.EqualFold(ctx.Value("host").(string), hostName) {
@@ -83,7 +81,10 @@ func TestTokenAuthCallBack(t *testing.T) {
 }
 
 // - standalone=1
-//   - Creates a standAlone connection with externalAuth = 1, valid token data.
+//   - Creates a standAlone connection with externalAuth = 1,
+//     expired token data and tests proper error is thrown.
+//   - Creates a standAlone connection with externalAuth = 1,
+//     valid token data.
 
 func TestTokenAuthStandAlone(t *testing.T) {
 	isTokenEnvConfigred(t)

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -20,7 +20,7 @@ import (
 func isTokenEnvConfigred(t *testing.T) {
 	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == "" ||
 		os.Getenv("GODROR_TEST_EXPIRED_PVTKEY") == "" ||
-		os.Getenv("GODROR_TEST_NEWPVTKEY") == ""||
+		os.Getenv("GODROR_TEST_NEWPVTKEY") == "" ||
 		os.Getenv("GODROR_TEST_NEWTOKEN") == "" {
 		t.Skip("skipping TestTokenAuthStandAlone test")
 	}
@@ -47,11 +47,18 @@ func TestTokenAuthCallBack(t *testing.T) {
 	P.Username = ""
 	P.Password.Reset()
 	const hostName = "test.clouddb.com"
+	const pno = 443
 	tokenCtx := context.WithValue(context.Background(), "host", hostName)
+	tokenCtx = context.WithValue(tokenCtx, "port", pno)
 	cb := func(ctx context.Context, tok *dsn.AccessToken) error {
 
 		if !strings.EqualFold(ctx.Value("host").(string), hostName) {
-			t.Errorf("TestTokenAuthCallBack: hostName got %s, wanted %s", ctx.Value("host"), hostName)
+			t.Errorf("TestTokenAuthCallBack: hostName got %s, wanted %s",
+				ctx.Value("host"), hostName)
+		}
+		if pno != ctx.Value("port").(int) {
+			t.Errorf("TestTokenAuthCallBack: port got %d, wanted %d",
+				ctx.Value("port").(int), pno)
 		}
 		newtoken := os.Getenv("GODROR_TEST_NEWTOKEN")
 		newpvtkey := os.Getenv("GODROR_TEST_NEWPVTKEY")
@@ -100,7 +107,7 @@ func TestTokenAuthStandAlone(t *testing.T) {
 	P.Password.Reset()
 
 	P.Token = os.Getenv("GODROR_TEST_EXPIRED_TOKEN")
-	P.PrivateKey = os.Getenv("GODROR_TEST_EXPIRED_NEWPVTKEY")
+	P.PrivateKey = os.Getenv("GODROR_TEST_EXPIRED_PVTKEY")
 	P.StandaloneConnection = true
 	P.ExternalAuth = true
 	t.Log("`" + P.StringWithPassword() + "`")

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/godror/godror/dsn"
 )
 
+func isTokenEnvConfigred(t *testing.T) {
+	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == nil ||
+		os.Getenv("GODROR_TEST_EXPIRED_PVTKEY") == nil ||
+		os.Getenv("GODROR_TEST_NEWPVTKEY") == nil ||
+		os.Getenv("GODROR_TEST_NEWTOKEN") == nil {
+		t.Skip("skipping TestTokenAuthStandAlone test")
+	}
+}
+
 // - standalone=0
 //   - Creates a homogeneous pool with externalAuth = 1.
 //     An Expired token is passed during create pool, registering a callback
@@ -27,7 +36,7 @@ import (
 //     the ping.
 
 func TestTokenAuthCallBack(t *testing.T) {
-	t.Parallel()
+	isTokenEnvConfigred(t)
 	ctx, cancel := context.WithTimeout(testContext("TokenAuthCallBack"), 30*time.Second)
 	defer cancel()
 	P, err := godror.ParseConnString(testConStr)
@@ -78,7 +87,7 @@ func TestTokenAuthCallBack(t *testing.T) {
 //   - Creates a standAlone connection with externalAuth = 1, valid token data.
 
 func TestTokenAuthStandAlone(t *testing.T) {
-	t.Parallel()
+	isTokenEnvConfigred(t)
 	ctx, cancel := context.WithTimeout(testContext("TokenAuthStandAlone"), 30*time.Second)
 	defer cancel()
 	P, err := godror.ParseDSN(testConStr)

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -19,8 +19,6 @@ import (
 
 func isTokenEnvConfigred(t *testing.T) {
 	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == "" ||
-		os.Getenv("GODROR_TEST_EXPIRED_PVTKEY") == "" ||
-		os.Getenv("GODROR_TEST_NEWPVTKEY") == "" ||
 		os.Getenv("GODROR_TEST_NEWTOKEN") == "" {
 		t.Skip("skipping TestTokenAuthStandAlone test")
 	}

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018, 2020 The Godror Authors
+// Copyright 2024 The Godror Authors
 //
 //
 // SPDX-License-Identifier: UPL-1.0 OR Apache-2.0

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/godror/godror/dsn"
 )
 
+// Checks if Token is configured. PrivateKey is only for IAM, hence
+// not verified.
 func isTokenEnvConfigred(t *testing.T) {
 	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == "" ||
 		os.Getenv("GODROR_TEST_NEWTOKEN") == "" {

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -30,8 +30,8 @@ func isTokenEnvConfigred(t *testing.T) {
 //   - Creates a homogeneous pool with externalAuth = 1.
 //     An Expired token is passed during create pool, registering a callback
 //     which provides a refresh token.
-//     When a Ping is done, callback is called as token is expired and the provided
-//     new token key and privateKey provided in the callback are used to perform
+//     When Ping is done, callback is called as token is expired and the
+//     provided new token key and privateKey are used to perform
 //     the ping.
 
 func TestTokenAuthCallBack(t *testing.T) {
@@ -89,9 +89,9 @@ func TestTokenAuthCallBack(t *testing.T) {
 
 // - standalone=1
 //   - Creates a standAlone connection with externalAuth = 1,
-//     expired token data and tests proper error is thrown.
+//     expired token data and check proper error is thrown.
 //   - Creates a standAlone connection with externalAuth = 1,
-//     valid token data.
+//     valid token data and check ping is successfull.
 
 func TestTokenAuthStandAlone(t *testing.T) {
 	isTokenEnvConfigred(t)

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -1,0 +1,100 @@
+// Copyright 2018, 2020 The Godror Authors
+//
+//
+// SPDX-License-Identifier: UPL-1.0 OR Apache-2.0
+
+package godror_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	godror "github.com/godror/godror"
+	"github.com/godror/godror/dsn"
+)
+
+func TestTokenAuthCallBack(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("TokenAuthCallBack"), 30*time.Second)
+	defer cancel()
+	P, err := godror.ParseConnString(testConStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset user and passwd
+	P.Username = ""
+	P.Password.Reset()
+	const hostName = "test.clouddb.com"
+	const pno = 443
+	tokenCtx := context.WithValue(context.Background(), "host", hostName)
+	tokenCtx = context.WithValue(tokenCtx, "port", pno)
+	cb := func(ctx context.Context, tok *dsn.AccessToken) error {
+
+		if !strings.EqualFold(ctx.Value("host").(string), hostName) {
+			t.Errorf("TestTokenAuthCallBack: hostName got %s, wanted %s", ctx.Value("host"), hostName)
+		}
+		newtoken := os.Getenv("GODROR_TEST_NEWTOKEN")
+		newpvtkey := os.Getenv("GODROR_TEST_NEWPVTKEY")
+		tok.Token = newtoken
+		tok.PrivateKey = newpvtkey
+		t.Log(" Token Passed in Callback", tok)
+		return nil
+	}
+
+	P.Token = os.Getenv("GODROR_TEST_TOKEN")
+	P.PrivateKey = os.Getenv("GODROR_TEST_PVTKEY")
+	P.PoolParams = godror.PoolParams{
+		MinSessions: 0, MaxSessions: 10, SessionIncrement: 1,
+		WaitTimeout:    5 * time.Second,
+		MaxLifeTime:    5 * time.Minute,
+		SessionTimeout: 1 * time.Minute,
+		TokenCB:        cb,
+		TokenCBCtx:     tokenCtx,
+	}
+	P.ExternalAuth = true
+	db := sql.OpenDB(godror.NewConnector(P))
+	defer db.Close()
+
+	// create OCI SessionPool
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTokenAuthStandAlone(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(testContext("TokenAuthStandAlone"), 30*time.Second)
+	defer cancel()
+	P, err := godror.ParseDSN(testConStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset user , password
+	P.Username = ""
+	P.Password.Reset()
+
+	P.Token = os.Getenv("GODROR_TEST_NEWTOKEN")
+	P.PrivateKey = os.Getenv("GODROR_TEST_NEWPVTKEY")
+	P.StandaloneConnection = true
+	P.ExternalAuth = true
+	t.Log("`" + P.StringWithPassword() + "`")
+	db, err := sql.Open("godror", P.StringWithPassword())
+	if err != nil {
+		t.Fatal(err)
+		// TBD check for token expiry
+		//ORA-25708:
+	}
+	defer db.Close()
+
+	// create OCI SessionPool
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/z_token_test.go
+++ b/z_token_test.go
@@ -8,7 +8,6 @@ package godror_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -19,10 +18,10 @@ import (
 )
 
 func isTokenEnvConfigred(t *testing.T) {
-	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == nil ||
-		os.Getenv("GODROR_TEST_EXPIRED_PVTKEY") == nil ||
-		os.Getenv("GODROR_TEST_NEWPVTKEY") == nil ||
-		os.Getenv("GODROR_TEST_NEWTOKEN") == nil {
+	if os.Getenv("GODROR_TEST_EXPIRED_TOKEN") == "" ||
+		os.Getenv("GODROR_TEST_EXPIRED_PVTKEY") == "" ||
+		os.Getenv("GODROR_TEST_NEWPVTKEY") == ""||
+		os.Getenv("GODROR_TEST_NEWTOKEN") == "" {
 		t.Skip("skipping TestTokenAuthStandAlone test")
 	}
 }


### PR DESCRIPTION
## Description
For Token Based Authentication, the connect string can an alias as mentioned [here](https://github.com/godror/godror/issues/328). This PR adds support to programatically supply token information; token and privateKey data.  For [IAM](https://node-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#iamtokenbasedauthentication) , token and privateKey needs to be provided. For [OAUTH](https://node-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#oauthtokenbasedauthentication), token is enough.

In case of pool config(`standAloneConnection=0`), callback be provided which is invoked when the token to connect to database is expired. The callback is supposed to fill the refresh token. The context for the callback is taken as `context.Context` type to just allow variable key/value pairs.  Should this be interface{} instead?

The refresh tokens are passed when callback is invoked during pool expansion. The C memory allocated for token data is freed on next invocation. Hence the `accessTokenCBs` map also has the previously returned token data. 

**Note:**
- If privateKey is not given but only token is given,  OAUTH based Authentication is internally tried.

- For token based authentication. Both homogeneous and externalAuth fields in the dpiPoolCreateParams structure must be set to 1. Incase of StandAlone externalAuth must be set to 1.

- token and privateKeys are not considered as part of pool key and hence single pool will be created for multiple sql.open calls with different token/privateKeys

- privateKey format should not have the comments ( -----BEGIN OPENSSH PRIVATE KEY-----
 ,  -----END OPENSSH PRIVATE KEY-----
 ) It has to be removed and passed

- ConnectionParams.StringWithPassword  only enables printing token/pvtkey 
- example of token and privatekey passed in sql.open for standalone=1

```
db, err := sql.open("godror", `user= password= connectString=token_auth_pgm 
        enableEvents=1 externalAuth=1  standaloneConnection=1 privateKey="MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC0XRkacj1w6PD7dAR/wCdUILJGDgHfQ92rDWZq7fS7TM+8HsZZu2hL9c1jFsMMVbK1XGk5+70+bZk+WN7Z7/p7SLnVKdwio4Eauxo7jYuwdf/fiDRjE5T2IcgA3Npl1mJb7qIBIbb6FLuSR3lsXH1UeVviGC7KSrlHulP799tQx11J9iamRhM5vSyjuxSOtlL5r7eiH93ZTU4wrALU48QAjkW/xRzP5ws+MAChLUGgE3hAuhY6YF7AIhh6I3Vm1BlMefTbd+GI1pz9Mm2mIC9zw7zh7SYoQectiU2ixCUAzmQgyniY96hKNOkgcCO8zzkVI+oE9aStDqmEhay8BSpdAgMBAAECggEAV4v0+mxHPH4lMrjO0j+wF1rDjdOQvxGPEE8xzmdwalXPY63Ac5/O8Uf/iMBsrpkOZI/Vl8qEwj+qqaOzkC+28o6LfVeTPdEFgrcc9ZkwG9g6+gKAAzNnE82z6g9JhzL3jU4YntoBmgPkRA2jd6CxSQabPfSlCZYZtyJPT7ewYdWC7THLZeaYQsVLzD8R1yPY/oVpxsHf/L00t3UHdWxaD8eu6yzGj4ms0ir0l2epIcrkZ52/+4CEF4IjidynSG+b3aUWHtHB0rahteTTiJ4Y9dObiFJvsQpOjmpNdbBhiUFrCt5Z9QwRUU+kLKSOuN8TFrK8R2/me/LIN4l+WlNawQKBgQDW7U1/R0ovzNzlLOVTmSduIeOrAxz9iax6ztEPPKzHkDbsuiQ6ne8JT73GRjznvxc4lA/oFUzvlvGcLH+LHQ2NQpR5p8UTGo06Q+yOkDBpHzT2furUHKV8jf4MBIIeagzeY9Pp0Wgs94swEJ+M6JeJt7o6yU7vRGEcqpgvflcwbQKBgQDW1OITghZa/AmEpzvgT4pGB69E2Q2GcHf5CAPC4RYyUOS8u2aGZwxjmPeV5JsfmFDiDa8+0TmEtkTQMNQeZS2kOj0CEj7w3tX03Na1Gy/DmEHMJCyYFEUpDd5jaOuPrnbfAdCK58x2hgXMgJhVgPOMAYDen5/N8nED7ZL0lEgLsQKBgQCyUJ18XMQzFk+qn+3/xtBM8jb2OhYCUAfWt+IBN0DOLVs0WlcWftPEMPFtH/cF+qekXEs6LPnwyZXZEZ4b59XHfha7PDMoX14Omi4YNY7EmIyTeccQhlfSF+hPRipCW5AjrkUx93fr3tEO5qvI92xKaTFL9prTrjK32t16geKKnQKBgQCZNG4ZfW8V6aGcEWs492Bjur06exQTKQfV9+o+wyiCL4BAO+DMvpZuPLtsEQCzUnt0ClBMmwbK5vVCB2BuYLdg5At3+60ZN8Ebg5Y2x7GTanSZ8b4/ok0EDxjmif9bkw7A0Nl5Bf+hEsj140s/xtton/XYTbu4Mkp4g6eGdmy+sQKBgQDIK7cDWl07V9JvnS7i2F030F64tUx+f56eOx8dDGuMritiBtyoTJe2WyG9i93WNoF/jJ93zQhxigZFhvYcJZPpZB5QcbyCo/v2llZdomdGeKh59d/mYIPeFKHYjB2VG+YvixcFprT+37nJ5PsMCelSb/Z8qgiCFPVFWrvsQ/ShTw=="  token=eyJraWQiOiJzY29wZWRfc2tfZGJfdG9rZW5faWFkX3lvMmwiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJvY2lkMS51c2VyLm9jMS4uYWFhYWFhYWE3dHdnNjV4b2d2aTJrdGEzaXF0dWd1c2lyc3FrYXQ1YzZyd3l5dXJvaGZ4ZXRsMzVycGpxIiwiaXNzIjoiYXV0aFNlcnZpY2Uub3JhY2xlLmNvbSIsInB0eXBlIjoidXNlciIsInNlc3NfZXhwIjoiV2VkLCAwOCBNYXkgMjAyNCAxMTo1ODowMCBVVEMiLCJkYlVzZXJOYW1lIjoibXlpYW11c2VyIiwidXNlck5hbWUiOiJNeUlBTVVzZXIiLCJhdWQiOiJ1cm46b3JhY2xlOmRiOm9jaWQxLnRlbmFuY3kub2MxLi5hYWFhYWFhYXhwbmdieTc0bnR1ZGt5NHNmcG1idGthdHZkN294eW15Y2dsc3Rqdml0cmptdms1eWJydnEiLCJwc3R5cGUiOiJuYXR2IiwidHR5cGUiOiJzY29wZWRfYWNjZXNzIiwic2NvcGUiOiJ1cm46b3JhY2xlOmRiOjppZDo6KiIsImV4cCI6MTcxNTE1MTQ4MCwiaWF0IjoxNzE1MTQ3ODgwLCJqdGkiOiI5MTA5YjlmMS1jODVjLTRkY2MtYWUxNy01MjZlYjg3OTY5MjciLCJ0ZW5hbnQiOiJvY2lkMS50ZW5hbmN5Lm9jMS4uYWFhYWFhYWF4cG5nYnk3NG50dWRreTRzZnBtYnRrYXR2ZDdveHlteWNnbHN0anZpdHJqbXZrNXlicnZxIiwiandrIjoie1wia2lkXCI6XCJvY2lkMS50ZW5hbmN5Lm9jMS4uYWFhYWFhYWF4cG5nYnk3NG50dWRreTRzZnBtYnRrYXR2ZDdveHlteWNnbHN0anZpdHJqbXZrNXlicnZxXCIsXCJuXCI6XCJ0RjBaR25JOWNPanctM1FFZjhBblZDQ3lSZzRCMzBQZHF3MW1hdTMwdTB6UHZCN0dXYnRvU19YTll4YkRERld5dFZ4cE9mdTlQbTJaUGxqZTJlXzZlMGk1MVNuY0lxT0JHcnNhTzQyTHNIWF8zNGcwWXhPVTlpSElBTnphWmRaaVctNmlBU0cyLWhTN2trZDViRng5VkhsYjRoZ3V5a3E1UjdwVC1fZmJVTWRkU2ZZbXBrWVRPYjBzbzdzVWpyWlMtYS0zb2hfZDJVMU9NS3dDMU9QRUFJNUZ2OFVjei1jTFBqQUFvUzFCb0JONFFMb1dPbUJld0NJWWVpTjFadFFaVEhuMDIzZmhpTmFjX1RKdHBpQXZjOE84NGUwbUtFSG5MWWxOb3NRbEFNNWtJTXA0bVBlb1NqVHBJSEFqdk04NUZTUHFCUFdrclE2cGhJV3N2QVVxWFFcIixcImVcIjpcIkFRQUJcIixcImt0eVwiOlwiUlNBXCIsXCJhbGdcIjpcIlJTMjU2XCIsXCJ1c2VcIjpcInNpZ1wifSJ9.R3aB-0A6LpMvK5y0Zjbpee1o5j6ScmxcV4udvWh1DSxyk_xn1Bae5Ll4RnOWZNTl-4barnr4GX8eAmZtGfVBuRkerjAlcpgT9ENEh7oYqT0kFyX9OVAYhYglaQ82JQkIgNL6sk7yrCzPt7p_In24pBbJKKiAI3l8eBLsnJprPX0jq4vZTqK4YiKJpUF3sLsIhzvAPhqxXNuazjAj2VfPsMY5HtOzwEXvxhvh492HZ_WioeXU90fZcqLVAcwyBpFdZ0TNpjFVitjgUboj0lur7oLY6KYMZi5D_cGUZDHa7ciyY52G-ajuIACK5wwsnpkxzZa2-kObnxxc_vJz9nQw_Q`
```


## Testing:
IAM and OAUTH testing for standalone and pool is done.